### PR TITLE
CFE-2965 Add link reference to sys.uqhost

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,10 +29,10 @@ Template:
     line_numbers: true
 
 vagrant:
-  version: "1.7.4"
+  version: "2.2.0"
 
 virtualbox:
-  version: "5.0.16"
+  version: "5.2.18"
 
 paginate: 500
 

--- a/_includes/header_nav.html
+++ b/_includes/header_nav.html
@@ -17,6 +17,32 @@
                         <option value="/docs/archive/">Version 3.0 (archive)</option>
                         <option value="/docs/archive/cf2-index.html">Version 2.0 (archive)</option>
                    </select>
+                   <script>
+                       function fillVersionWrapperSelect(url) {
+                           // Fills above <select> with data from a json file.
+                           var xmlhttp = new XMLHttpRequest();
+                           xmlhttp.open('GET', url, true);
+                           xmlhttp.onreadystatechange = function() {
+                               if (xmlhttp.readyState != 4 || xmlhttp.status != 200) {
+                                   return
+                               }
+                               var str = ''; //generated HTML
+                               var data = JSON.parse(xmlhttp.responseText);
+                               for(var i = 0; i<data.docs.length; i++){
+                                   var branch = data.docs[i];
+                                   var selected = '';
+                                   if(location.pathname.indexOf(branch.Link)==0){
+                                       // this is version that we're currently looking at
+                                       selected = ' selected';
+                                   }
+                                   str += '<option value="' + branch.Link + '"' + selected + '>' + branch.Title + '</option>';
+                               }
+                               document.querySelector('#top_version_wrapper select').innerHTML = str;
+                           }
+                           xmlhttp.send(null);
+                       };
+                       document.addEventListener("DOMContentLoaded", function() {fillVersionWrapperSelect('/docs/branches.json')});
+                   </script>
                 </div>
                 <div class="top_search_form">
                    <form id="cse-search-box" action="search.html">

--- a/_includes/header_nav.html
+++ b/_includes/header_nav.html
@@ -4,18 +4,7 @@
             <div class="float-right">
                <div id="top_version_wrapper">
                    <select onchange="selectVersion(this.options[this.selectedIndex].value)">
-                        <option value="/docs/master/index.html" selected>master</option>
-                        <option value="/docs/3.13/index.html">Version 3.13 (non-LTS)</option>
-                        <option value="/docs/3.12/index.html">Version 3.12 (LTS)</option>
-                        <option value="/docs/3.10/index.html">Version 3.10 (LTS)</option>
-                        <option value="/docs/3.7/index.html">Version 3.7 (EOL)</option>
-                        <option value="/docs/3.11/index.html">Version 3.11 (EOL)</option>
-                        <option value="/docs/3.9/index.html">Version 3.9 (EOL)</option>
-                        <option value="/docs/3.8/index.html">Version 3.8 (EOL)</option>
-                        <option value="/docs/3.6/index.html">Version 3.6 (EOL)</option>
-                        <option value="/docs/3.5/index.html">Version 3.5 (EOL)</option>
-                        <option value="/docs/archive/">Version 3.0 (archive)</option>
-                        <option value="/docs/archive/cf2-index.html">Version 2.0 (archive)</option>
+			{% include header_nav_options.html %}
                    </select>
                    <script>
                        function fillVersionWrapperSelect(url) {

--- a/_includes/header_nav.html
+++ b/_includes/header_nav.html
@@ -5,9 +5,10 @@
                <div id="top_version_wrapper">
                    <select onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
                         <option value="/docs/master/index.html" selected>master</option>
-                        <option value="/docs/3.12/index.html">Version 3.12 (non-LTS)</option>
+                        <option value="/docs/3.13/index.html">Version 3.13 (non-LTS)</option>
+                        <option value="/docs/3.12/index.html">Version 3.12 (LTS)</option>
                         <option value="/docs/3.10/index.html">Version 3.10 (LTS)</option>
-                        <option value="/docs/3.7/index.html">Version 3.7 (LTS)</option>
+                        <option value="/docs/3.7/index.html">Version 3.7 (EOL)</option>
                         <option value="/docs/3.11/index.html">Version 3.11 (EOL)</option>
                         <option value="/docs/3.9/index.html">Version 3.9 (EOL)</option>
                         <option value="/docs/3.8/index.html">Version 3.8 (EOL)</option>

--- a/_includes/header_nav.html
+++ b/_includes/header_nav.html
@@ -3,7 +3,7 @@
         <div id="top_form" class="group">
             <div class="float-right">
                <div id="top_version_wrapper">
-                   <select onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
+                   <select onchange="selectVersion(this.options[this.selectedIndex].value)">
                         <option value="/docs/master/index.html" selected>master</option>
                         <option value="/docs/3.13/index.html">Version 3.13 (non-LTS)</option>
                         <option value="/docs/3.12/index.html">Version 3.12 (LTS)</option>
@@ -34,12 +34,20 @@
                                    if(location.pathname.indexOf(branch.Link)==0){
                                        // this is version that we're currently looking at
                                        selected = ' selected';
+                                       window.currentVersionLink = branch.Link;
                                    }
                                    str += '<option value="' + branch.Link + '"' + selected + '>' + branch.Title + '</option>';
                                }
                                document.querySelector('#top_version_wrapper select').innerHTML = str;
                            }
                            xmlhttp.send(null);
+                       };
+                       function selectVersion(value){
+                           if(value.indexOf('archive')==-1 && window.currentVersionLink){
+                               window.location = window.location.href.replace(window.currentVersionLink, value);
+                           } else {
+                               window.location = value;
+                           }
                        };
                        document.addEventListener("DOMContentLoaded", function() {fillVersionWrapperSelect('/docs/branches.json')});
                    </script>

--- a/_references.md
+++ b/_references.md
@@ -37,3 +37,4 @@
 [sys.policy_entry_filename]: reference-special-variables-sys.html#sys-policy_entry_filename
 [supported versions]: https://cfengine.com/extended-support/
 [Inventory API]: reference-enterprise-api-ref-inventory.html
+[sys.uqhost]: reference-special-variables-sys.html#sys-uqhost

--- a/_scripts/cfdoc_patch_header_nav.py
+++ b/_scripts/cfdoc_patch_header_nav.py
@@ -1,0 +1,37 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2013 CFEngine AS
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import urllib
+import json
+import sys
+
+def patch(current_branch):
+    url = "https://docs.cfengine.com/docs/branches.json"
+    response = urllib.urlopen(url)
+    data = json.loads(response.read())
+    with open("_includes/header_nav_options.html", "w") as f:
+        for branch in data['docs']:
+            selected = ''
+            if branch['Version'] == current_branch:
+                selected = ' selected'
+            print >>f, '<option value="%s"%s>%s</option>' % (
+                    branch['Link'], selected, branch['Title'])

--- a/_scripts/cfdoc_preprocess.py
+++ b/_scripts/cfdoc_preprocess.py
@@ -29,6 +29,7 @@ import cfdoc_macros as macros
 import cfdoc_printsource as printsource
 import cfdoc_git as git
 import cfdoc_qa as qa
+import cfdoc_patch_header_nav as patch_header_nav
 import sys
 import os
 
@@ -75,6 +76,13 @@ try:
 	printsource.run(config)
 except:
 	print "cfdoc_printsource: Error generating print-pages"
+	sys.stdout.write("      Exception: ")
+	print sys.exc_info()
+
+try:
+	patch_header_nav.patch(sys.argv[1])
+except:
+	print "cfdoc_patch_header_nav: Error patching header navigation"
 	sys.stdout.write("      Exception: ")
 	print sys.exc_info()
 


### PR DESCRIPTION
sys.fqhost links to sys.uqhost, but the link is broken. Probably because it falls later on the same page and it isn't properly resolved. We have had to do similar for sys.policy_entry_dirname and sys.policy_entry_filename in the past.

This change adds a reference link for sys.uqhost so that it will be sure to resolve.